### PR TITLE
fix: adapt new version of homeassistant with jwt version 2.x.x

### DIFF
--- a/custom_components/havcs/http.py
+++ b/custom_components/havcs/http.py
@@ -104,7 +104,7 @@ class HavcsAuthorizeView(HomeAssistantView):
         if login_attemp['count'] >= 5 and datetime.now() - login_attemp['first_time'] < timedelta(minutes=1):
             _LOGGER.info("[%s][auth]Too many login attempts Login attempt with invalid authentication", LOGGER_NAME)
             return web.Response(body='403 (╯‵□′)╯︵ ┴─┴ 失败尝试次数过多暂时拉入小黑屋', status=403)
-        
+
         client_id = parts.scheme + '://' + parts.netloc
         data = {
             "client_id": client_id,
@@ -232,7 +232,10 @@ class HavcsTokenView(HomeAssistantView):
                 result['expires_in'] = int(self._expiration.total_seconds())
                 _LOGGER.debug("[%s][auth] get access token[%s] with default expiration, try to update expiration param and get new access token through another refresh token request.", LOGGER_NAME, result.get('access_token'))
                 access_token = result.get('access_token')
-                await havcs_util.async_update_token_expiration(access_token, self._hass, self._expiration)
+                done = await havcs_util.async_update_token_expiration(access_token, self._hass, self._expiration)
+                if not done:
+                    _LOGGER.error("[%s][auth] update token expiration failed.", LOGGER_NAME, self._token_url)
+                    return web.Response(status=500)
 
                 try:
                     refresh_token_data = {'client_id': data.get('client_id'), 'grant_type': 'refresh_token', 'refresh_token': result.get('refresh_token')}
@@ -242,7 +245,7 @@ class HavcsTokenView(HomeAssistantView):
                 except(asyncio.TimeoutError, aiohttp.ClientError):
                     _LOGGER.error("[%s][auth] fail to get new access token, access %s in local network: timeout", LOGGER_NAME, self._token_url)
                     return web.Response(status=response.status)
-                
+
                 try:
                     refresh_token_result = await response.json()
                     _LOGGER.debug("[%s][auth] get new access token[%s] with new expiration.", LOGGER_NAME, refresh_token_result.get('access_token'))
@@ -287,7 +290,7 @@ class HavcsSettingsView(HomeAssistantView):
     def __init__(self, hass, settings_schema):
         self._hass = hass
         self._settings_schema = settings_schema
-    
+
     async def get(self, request):
         return web.Response(body='404 (￣ε￣) 访问到空气页面 (￣з￣)', status=404)
 
@@ -313,7 +316,7 @@ class HavcsSettingsView(HomeAssistantView):
                     return self.json({ 'code': 'error', 'Msg': msg})
                 except Exception as e:
                     _LOGGER.error("[%s][device] fail to update settings (%s) : %s", LOGGER_NAME, settings, traceback.format_exc())
-                    return self.json({ 'code': 'error', 'Msg': repr(e)})      
+                    return self.json({ 'code': 'error', 'Msg': repr(e)})
         elif action == 'get':
             settings = self._hass.data[INTEGRATION][DATA_HAVCS_SETTINGS]
             if settings:
@@ -331,7 +334,7 @@ class HavcsDeviceView(HomeAssistantView):
     def __init__(self, hass, device_schema):
         self._hass = hass
         self._device_schema = device_schema
-        
+
         local = hass.config.path("custom_components/" + INTEGRATION + "/html")
         if os.path.isdir(local):
             hass.http.register_static_path('/havcs', local, False)
@@ -399,7 +402,7 @@ class HavcsDeviceView(HomeAssistantView):
                 except Exception as e:
                     _LOGGER.error("[%s][device] fail to update device (%s: %s) : %s", LOGGER_NAME, device_id, device, traceback.format_exc())
                     return self.json({ 'code': 'error', 'Msg': repr(e)})
-        elif action == 'export': 
+        elif action == 'export':
             response = web.FileResponse(os.path.join(self._hass.config.config_dir, 'havcs-ui.yaml'), headers={'Content-Disposition': 'havcs-ui.yaml'})
             response.enable_compression()
             return response
@@ -433,7 +436,7 @@ class HavcsHttpManager:
         self._expiration = None
         self._device_schema = device_schema
         self._settings_schema = settings_schema
-    
+
     def set_expiration(self, expiration):
         self._expiration = expiration
 

--- a/custom_components/havcs/util.py
+++ b/custom_components/havcs/util.py
@@ -96,7 +96,7 @@ def get_token_from_command(command):
 
 async def async_update_token_expiration(access_token, hass, expiration):
     try:
-        if version.parse(jwt.__version__ < "2.0.0"):
+        if version.parse(jwt.__version__) < version.parse("2.0.0"):
             unverif_claims = jwt.decode(access_token, verify=False)
         else:
             unverif_claims = jwt.decode(

--- a/custom_components/havcs/util.py
+++ b/custom_components/havcs/util.py
@@ -100,7 +100,7 @@ async def async_update_token_expiration(access_token, hass, expiration):
             unverif_claims = jwt.decode(access_token, verify=False)
         else:
             unverif_claims = jwt.decode(
-                token, algorithms=["HS256"], options={"verify_signature": False}
+                access_token, algorithms=["HS256"], options={"verify_signature": False}
             )
         refresh_token = await hass.auth.async_get_refresh_token(cast(str, unverif_claims.get('iss')))
         for user in hass.auth._store._users.values():

--- a/custom_components/havcs/util.py
+++ b/custom_components/havcs/util.py
@@ -6,6 +6,7 @@ import re
 import jwt
 from typing import cast
 import logging
+from packaging import version
 
 _LOGGER = logging.getLogger(__name__)
 # _LOGGER.setLevel(logging.DEBUG)
@@ -95,7 +96,12 @@ def get_token_from_command(command):
 
 async def async_update_token_expiration(access_token, hass, expiration):
     try:
-        unverif_claims = jwt.decode(access_token, verify=False)
+        if version.parse(jwt.__version__ < "2.0.0"):
+            unverif_claims = jwt.decode(access_token, verify=False)
+        else:
+            unverif_claims = jwt.decode(
+                token, algorithms=["HS256"], options={"verify_signature": False}
+            )
         refresh_token = await hass.auth.async_get_refresh_token(cast(str, unverif_claims.get('iss')))
         for user in hass.auth._store._users.values():
             if refresh_token.id in user.refresh_tokens and refresh_token.access_token_expiration != expiration:
@@ -103,6 +109,7 @@ async def async_update_token_expiration(access_token, hass, expiration):
                 refresh_token.access_token_expiration = expiration
                 user.refresh_tokens[refresh_token.id] = refresh_token
                 hass.auth._store._async_schedule_save()
-                break
+                return True
     except jwt.InvalidTokenError:
         _LOGGER.debug("[util] access_token[%s] is invalid, try another reauthorization on website", access_token)
+        return False


### PR DESCRIPTION
homeassistant updated jwt module to version 2  ([#55911](https://github.com/home-assistant/core/pull/55911)) , this jwt version
deprecated jwt.decode verify_expiration and require explicit
algorithms parameter ([changelog](https://pyjwt.readthedocs.io/en/stable/changelog.html?highlight=verify#require-explicit-algorithms-in-jwt-decode-by-default)). the deprecated may cause HAVCS update access_token's expiration
failed.

this pr fix this problem and **make it works on jwt version 1 and version 2 both** by check the jwt version and choice appropriate `decode` method.